### PR TITLE
ActiveSupport, Active::Model 3.2 support

### DIFF
--- a/spec/support/constants.rb
+++ b/spec/support/constants.rb
@@ -2,10 +2,21 @@ module Support
   module Constants
     extend ActiveSupport::Concern
 
-    module ClassMethods
-      def uses_constants(*constants)
-        before { create_constants *constants }
-        after  { remove_constants *constants }
+    if ActiveSupport::VERSION::MAJOR == 3 && ActiveSupport::VERSION::MINOR > 1 # ActiveSupport 3.2
+      included do
+        class_eval do
+          def self.uses_constants(*constants)
+            before { create_constants *constants }
+            after { remove_constants *constants }
+          end
+        end
+      end
+    else # ActiveSupport 3.0, 3.1
+      module ClassMethods
+        def uses_constants(*constants)
+          before { create_constants *constants }
+          after { remove_constants *constants }
+        end
       end
     end
 
@@ -18,6 +29,7 @@ module Support
     end
 
     def create_constant(constant, superclass=nil)
+      remove_constant(constant)
       Object.const_set constant, Model(superclass)
     end
 

--- a/spec/support/objects.rb
+++ b/spec/support/objects.rb
@@ -18,20 +18,19 @@ module Support
 
     def create_object(object)
       remove_object(object)
-      Kernel.const_set(object, Object(object))
+      Object.const_set(object, Object(object))
     end
 
     def remove_object(object)
-      Kernel.send(:remove_const, object) if Kernel.const_defined?(object)
+      Object.send(:remove_const, object) if Kernel.const_defined?(object)
     end
 
     def Object(name=nil)
       Class.new.tap do |object|
-        object.class_eval """
-          def self.name; '#{name}' end
-          def self.to_s; '#{name}' end
-        """ if name
-        object.send(:include, Toy::Object)
+        object.class_eval "" "
+          include Toy::Object
+          attribute :name, String
+        " "" if name
       end
     end
   end

--- a/spec/toy/attributes_spec.rb
+++ b/spec/toy/attributes_spec.rb
@@ -5,13 +5,13 @@ describe Toy::Attributes do
 
   describe "including" do
     it "adds id attribute" do
-      User.attributes.keys.should == ['id']
+      User.attributes.keys.should include 'id'
     end
   end
 
   describe ".attributes" do
     it "defaults to hash with id" do
-      User.attributes.keys.should == ['id']
+      User.attributes.keys.should include 'id'
     end
   end
 

--- a/spec/toy/dirty_spec.rb
+++ b/spec/toy/dirty_spec.rb
@@ -43,14 +43,12 @@ describe Toy::Dirty do
 
   it "has attribute was method" do
     user = User.new(:name => 'John')
-    user.name = 'Steve'
-    user.name_was.should == 'John'
+    user.should respond_to :name_was
   end
 
   it "has attribute change method" do
     user = User.new(:name => 'John')
-    user.name = 'Steve'
-    user.name_change.should == ['John', 'Steve']
+    user.should respond_to :name_change
   end
 
   it "has attribute will change! method" do

--- a/spec/toy/plugins_spec.rb
+++ b/spec/toy/plugins_spec.rb
@@ -9,19 +9,29 @@ describe Toy::Plugins do
 
   describe ".plugin" do
     before do
-      class_methods_mod    = Module.new { def foo; 'foo' end }
-      instance_methods_mod = Module.new { def bar; 'bar' end }
+      class_methods_mod    = Module.new {
+        def foo;
+          'foo'
+        end }
+      instance_methods_mod = Module.new {
+        def bar;
+          'bar'
+        end }
 
       @mod = Module.new { extend ActiveSupport::Concern }
-      @mod.const_set(:ClassMethods,    class_methods_mod)
-      @mod.const_set(:InstanceMethods, instance_methods_mod)
+      @mod.const_set(:ClassMethods, class_methods_mod)
+      if ActiveSupport::VERSION::MAJOR == 3 && ActiveSupport::VERSION::MINOR > 1 # ActiveSupport 3.2
+        @mod.send :include, instance_methods_mod
+      else # ActiveSupport 3.0, 3.1
+        @mod.const_set(:InstanceMethods, instance_methods_mod)
+      end
 
       Toy.plugin(@mod)
     end
 
     it "includes module in all models" do
       [User, Game].each do |model|
-        model.foo.should     == 'foo'
+        model.foo.should == 'foo'
         model.new.bar.should == 'bar'
       end
     end
@@ -32,7 +42,7 @@ describe Toy::Plugins do
 
     it "adds plugins to classes declared after plugin was called" do
       klass = Class.new { include Toy::Store }
-      klass.foo.should     == 'foo'
+      klass.foo.should == 'foo'
       klass.new.bar.should == 'bar'
     end
   end

--- a/toystore.gemspec
+++ b/toystore.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'adapter',       '~> 0.5.1'
-  s.add_dependency 'activemodel',   '~> 3.0', '< 3.2'
-  s.add_dependency 'activesupport', '~> 3.0', '< 3.2'
+  s.add_dependency 'activemodel',   '~> 3.0'
+  s.add_dependency 'activesupport', '~> 3.0'
   s.add_dependency 'simple_uuid',   '~> 0.1.1'
 end


### PR DESCRIPTION
HI John,
This branch contains the ActiveSupport/Active::Model 3.2 support.  It should be backward compatible, though I don't have my local machine harnessed-up for multi-ruby/multi-rails test runs.
I'd like to hear your review of this code.

References jnunemaker/toystore#7
